### PR TITLE
Feature admin editing

### DIFF
--- a/quest_maker_app/admin.py
+++ b/quest_maker_app/admin.py
@@ -1,10 +1,38 @@
 from django.contrib import admin
+from django import forms
+from django.db import models
 from .models import Quest, Waypoint, QuestTemplate, UserQuest, DailyMile
+
+# Enable inline editing of waypoints inside QuestTemplate editor.
+class WaypointInline(admin.TabularInline):
+    model = Waypoint
+    # Configure number and text box size for waypoint descriptions:
+    extra = 10
+    formfield_overrides = {
+        models.TextField:
+        {'widget': forms.Textarea(attrs={'rows': 1, 'cols': 40})},
+    }
+
+
+class QuestTemplateAdmin(admin.ModelAdmin):
+    inlines = [
+        WaypointInline
+    ]
+    exclude = ()
+
+
+class QuestAdmin(admin.ModelAdmin):
+    inlines = [
+        WaypointInline
+    ]
+    exclude = ()
+
+
 
 
 # Register your models here.
 admin.site.register(Quest)
 admin.site.register(Waypoint)
-admin.site.register(QuestTemplate)
+admin.site.register(QuestTemplate, QuestTemplateAdmin)
 admin.site.register(UserQuest)
 admin.site.register(DailyMile)

--- a/quest_maker_app/migrations/0002_auto_20150605_2306.py
+++ b/quest_maker_app/migrations/0002_auto_20150605_2306.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import datetime
+from django.utils.timezone import utc
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('quest_maker_app', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='quest',
+            name='start_date',
+            field=models.DateField(default=datetime.datetime(2015, 6, 6, 4, 6, 3, 717390, tzinfo=utc)),
+        ),
+    ]

--- a/quest_maker_app/migrations/0003_auto_20150605_2306.py
+++ b/quest_maker_app/migrations/0003_auto_20150605_2306.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.utils.timezone
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('quest_maker_app', '0002_auto_20150605_2306'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='quest',
+            name='start_date',
+            field=models.DateField(default=django.utils.timezone.now),
+        ),
+    ]

--- a/quest_maker_app/models.py
+++ b/quest_maker_app/models.py
@@ -1,9 +1,10 @@
 from django.db import models
 from django.contrib.auth.models import User
+from django.utils import timezone
 
 NOTABILITY_CHOICES = (
-    ("high", "high"), 
-    ("medium", "medium"), 
+    ("high", "high"),
+    ("medium", "medium"),
     ("low", "low")
     )
 
@@ -21,19 +22,19 @@ class Quest(models.Model):
     """
 
     leader = models.ForeignKey(User, related_name="quests_led")
-    users = models.ManyToManyField(User, through="UserQuest", 
+    users = models.ManyToManyField(User, through="UserQuest",
                                    through_fields=("quest", "user"))
     name = models.CharField(max_length=100, db_index=True)
     template = models.ForeignKey(QuestTemplate)
-    start_date = models.DateField(auto_now=True)
-    
-    @property 
+    start_date = models.DateField(default=timezone.now)
+
+    @property
     def waypoints(self):
         return self.template.waypoints
 
     def get_latest_user_info(self):
         """Get a dict of all users, their current distances, and the waypoints
-        they are currently at 
+        they are currently at
         """
         info = {}
         for user_quest in self.user_quests:
@@ -59,7 +60,7 @@ class Waypoint(models.Model):
     distance_from_start = models.FloatField(null=True, blank=True)
     description = models.TextField(null=True, blank=True)
     notability = models.CharField(choices=NOTABILITY_CHOICES, max_length=10)
-    
+
     def __unicode__(self):
         return "Waypoint {}, id={}".format(self.name, self.pk)
 


### PR DESCRIPTION
Inline editing of waypoints in QuestTemplate admin editor makes it easy to add new quest templates. Additionally, Quest start_date now defaults to the current date but can be edited inside the Quest editor if desired.
